### PR TITLE
ENS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,5 @@ jobs:
 
       - name: Run Forge tests
         run: |
-          forge test -vvv
+          forge test -vvv --fork-url https://eth.llamarpc.com
         id: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,5 @@ jobs:
 
       - name: Run Forge tests
         run: |
-          forge test -vvv --fork-url https://eth.llamarpc.com
+          forge test -vvv --fork-url ${{ secrets.RPC_URL }}
         id: test

--- a/src/COWShed.sol
+++ b/src/COWShed.sol
@@ -1,6 +1,7 @@
 import { ICOWAuthHook, Call } from "./ICOWAuthHook.sol";
 import { LibAuthenticatedHooks } from "./LibAuthenticatedHooks.sol";
 import { COWShedStorage, IMPLEMENTATION_STORAGE_SLOT } from "./COWShedStorage.sol";
+import { REVERSE_REGISTRAR } from "./ens.sol";
 
 contract COWShed is ICOWAuthHook, COWShedStorage {
     error InvalidSignature();
@@ -38,6 +39,11 @@ contract COWShed is ICOWAuthHook, COWShedStorage {
         _state().initialized = true;
         _state().trustedExecutor = factory;
         emit TrustedExecutorChanged(address(0), factory);
+
+        if (block.chainid == 1) {
+            // transfer ownership of reverse ENS record to the factory contract
+            REVERSE_REGISTRAR.claimWithResolver(factory, factory);
+        }
     }
 
     function executeHooks(Call[] calldata calls, bytes32 nonce, uint256 deadline, bytes calldata signature) external {

--- a/src/COWShedFactory.sol
+++ b/src/COWShedFactory.sol
@@ -10,7 +10,6 @@ contract COWShedFactory is COWShedResolver {
     event COWShedBuilt(address user, address shed);
 
     address public immutable implementation;
-    COWShedResolver public immutable resolver;
 
     mapping(address => address) public ownerOf;
 

--- a/src/COWShedResolver.sol
+++ b/src/COWShedResolver.sol
@@ -6,11 +6,11 @@ import { LibString } from "solady/utils/LibString.sol";
 abstract contract COWShedResolver is INameResolver, IAddrResolver {
     mapping(bytes32 => address) public reverseResolutionNodeToAddress;
     mapping(bytes32 => address) public forwardResolutionNodeToAddress;
-    bytes32 immutable baseName_;
+    bytes32 immutable baseNameSmallString;
     bytes32 immutable baseNode;
 
     constructor(bytes32 bName, bytes32 bNode) {
-        baseName_ = bName;
+        baseNameSmallString = bName;
         baseNode = bNode;
     }
 
@@ -27,7 +27,7 @@ abstract contract COWShedResolver is INameResolver, IAddrResolver {
     }
 
     function baseName() public view returns (string memory) {
-        return LibString.fromSmallString(baseName_);
+        return LibString.fromSmallString(baseNameSmallString);
     }
 
     function _setReverseNode(address user, address proxy) internal {

--- a/src/COWShedResolver.sol
+++ b/src/COWShedResolver.sol
@@ -1,0 +1,49 @@
+import {
+    INameResolver, IReverseRegistrar, IENS, IAddrResolver, ENS, ADDR_REVERSE_NODE, sha3HexAddress
+} from "./ens.sol";
+import { LibString } from "solady/utils/LibString.sol";
+
+abstract contract COWShedResolver is INameResolver, IAddrResolver {
+    mapping(bytes32 => address) public reverseResolutionNodeToAddress;
+    mapping(bytes32 => address) public forwardResolutionNodeToAddress;
+    bytes32 immutable baseName_;
+    bytes32 immutable baseNode;
+
+    constructor(bytes32 bName, bytes32 bNode) {
+        baseName_ = bName;
+        baseNode = bNode;
+    }
+
+    function name(bytes32 node) external view returns (string memory) {
+        address who = reverseResolutionNodeToAddress[node];
+        if (who == address(0)) return "";
+        return string(abi.encodePacked(LibString.toHexStringChecksummed(who), ".", baseName()));
+    }
+
+    function addr(bytes32 node) external view returns (address) {
+        address user = forwardResolutionNodeToAddress[node];
+        if (user == address(0)) return address(0);
+        return user;
+    }
+
+    function baseName() public view returns (string memory) {
+        return LibString.fromSmallString(baseName_);
+    }
+
+    function _setReverseNode(address user, address proxy) internal {
+        bytes32 node = keccak256(abi.encodePacked(ADDR_REVERSE_NODE, sha3HexAddress(proxy)));
+        reverseResolutionNodeToAddress[node] = user;
+    }
+
+    function _setForwardNode(address user, address proxy) internal {
+        _setForwardNodeForAddressString(LibString.toHexStringChecksummed(user), proxy);
+        _setForwardNodeForAddressString(LibString.toHexString(user), proxy);
+    }
+
+    function _setForwardNodeForAddressString(string memory labelString, address proxy) internal {
+        bytes32 label = keccak256(abi.encodePacked(bytes(labelString)));
+        ENS.setSubnodeRecord(baseNode, label, address(this), address(this), type(uint64).max);
+        bytes32 subnode = keccak256(abi.encodePacked(baseNode, label));
+        forwardResolutionNodeToAddress[subnode] = proxy;
+    }
+}

--- a/src/ens.sol
+++ b/src/ens.sol
@@ -1,0 +1,50 @@
+interface IReverseRegistrar {
+    function claim(address owner) external returns (bytes32 node);
+    function claimWithResolver(address owner, address resolver) external returns (bytes32 node);
+    function setName(string calldata name) external returns (bytes32 node);
+    function node(address) external view returns (bytes32 node);
+}
+
+interface INameResolver {
+    function name(bytes32 node) external view returns (string memory);
+}
+
+interface IENS {
+    function setSubnodeRecord(bytes32 node, bytes32 label, address owner, address resolver, uint64 ttl) external;
+    function resolver(bytes32 node) external view returns (address);
+    function owner(bytes32 node) external view returns (address);
+    function setResolver(bytes32 node, address resolver) external;
+}
+
+interface IAddrResolver {
+    function addr(bytes32 node) external view returns (address);
+}
+
+IReverseRegistrar constant REVERSE_REGISTRAR = IReverseRegistrar(0xa58E81fe9b61B5c3fE2AFD33CF304c454AbFc7Cb);
+IENS constant ENS = IENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
+bytes32 constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
+
+bytes32 constant sha3HexLookup = 0x3031323334353637383961626364656600000000000000000000000000000000;
+
+/**
+ * @dev An optimised function to compute the sha3 of the lower-case
+ *      hexadecimal representation of an Ethereum address.
+ *      Copied over from [ReverseRegistrar.sol](https://github.com/ensdomains/ens-contracts/blob/8e8cf71bc50fb1a5055dcf3d523d2ed54e725d28/contracts/reverseRegistrar/ReverseRegistrar.sol#L157-L181)
+ * @param who The address to hash
+ * @return ret The SHA3 hash of the lower-case hexadecimal encoding of the
+ *         input address.
+ */
+function sha3HexAddress(address who) pure returns (bytes32 ret) {
+    assembly {
+        for { let i := 40 } gt(i, 0) { } {
+            i := sub(i, 1)
+            mstore8(i, byte(and(who, 0xf), sha3HexLookup))
+            who := div(who, 0x10)
+            i := sub(i, 1)
+            mstore8(i, byte(and(who, 0xf), sha3HexLookup))
+            who := div(who, 0x10)
+        }
+
+        ret := keccak256(0, 40)
+    }
+}

--- a/src/ens.sol
+++ b/src/ens.sol
@@ -1,3 +1,5 @@
+/// @dev IReverseRegistrar interface as defined in ENSIP-3.
+///      See: https://github.com/ensdomains/ens-contracts/blob/8e8cf71bc50fb1a5055dcf3d523d2ed54e725d28/contracts/reverseRegistrar/IReverseRegistrar.sol
 interface IReverseRegistrar {
     function claim(address owner) external returns (bytes32 node);
     function claimWithResolver(address owner, address resolver) external returns (bytes32 node);
@@ -5,10 +7,14 @@ interface IReverseRegistrar {
     function node(address) external view returns (bytes32 node);
 }
 
+/// @dev INameResolver interface as defined in ENSIP-3
+///      See: https://github.com/ensdomains/ens-contracts/blob/8e8cf71bc50fb1a5055dcf3d523d2ed54e725d28/contracts/resolvers/profiles/INameResolver.sol
 interface INameResolver {
     function name(bytes32 node) external view returns (string memory);
 }
 
+/// @dev ENS registry interface as defined in ENSIP-1
+///      See: https://github.com/ensdomains/ens-contracts/blob/8e8cf71bc50fb1a5055dcf3d523d2ed54e725d28/contracts/registry/ENS.sol
 interface IENS {
     function setSubnodeRecord(bytes32 node, bytes32 label, address owner, address resolver, uint64 ttl) external;
     function resolver(bytes32 node) external view returns (address);
@@ -16,6 +22,8 @@ interface IENS {
     function setResolver(bytes32 node, address resolver) external;
 }
 
+/// @dev ENS address resolution interface as defined in ENSIP-1
+///      See: https://github.com/ensdomains/ens-contracts/blob/8e8cf71bc50fb1a5055dcf3d523d2ed54e725d28/contracts/resolvers/profiles/IAddrResolver.sol
 interface IAddrResolver {
     function addr(bytes32 node) external view returns (address);
 }

--- a/src/ens.sol
+++ b/src/ens.sol
@@ -22,9 +22,11 @@ interface IAddrResolver {
 
 IReverseRegistrar constant REVERSE_REGISTRAR = IReverseRegistrar(0xa58E81fe9b61B5c3fE2AFD33CF304c454AbFc7Cb);
 IENS constant ENS = IENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
+/// @dev namehash of `addr.reverse`
 bytes32 constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
 
-bytes32 constant sha3HexLookup = 0x3031323334353637383961626364656600000000000000000000000000000000;
+/// @dev constant used in the sha3HexAddress, also copied over.
+bytes32 constant sha3HexLookup = "0123456789abcdef";
 
 /**
  * @dev An optimised function to compute the sha3 of the lower-case

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -6,10 +6,6 @@ import { IMPLEMENTATION_STORAGE_SLOT } from "src/COWShedStorage.sol";
 import { ENS, INameResolver, IAddrResolver } from "src/ens.sol";
 import { LibString } from "solady/utils/LibString.sol";
 
-interface ICustomVM {
-    function ensNamehash(string calldata) external pure returns (bytes32);
-}
-
 contract LibAuthenticatedHooksCalldataProxy {
     function executeHooksMessageHash(Call[] calldata calls, bytes32 nonce, uint256 deadline)
         external
@@ -83,8 +79,6 @@ contract BaseTest is Test {
     SmartWallet smartWallet;
     address smartWalletProxyAddr;
     COWShed smartWalletProxy;
-
-    ICustomVM customVm = ICustomVM(address(vm));
 
     function setUp() external virtual {
         uint256 nonce = vm.getNonce(address(this));
@@ -196,7 +190,7 @@ contract BaseTest is Test {
 
     function _reverseResolve(address addr) internal view returns (string memory) {
         bytes32 node =
-            customVm.ensNamehash(string(abi.encodePacked(LibString.toHexStringNoPrefix(addr), ".", "addr.reverse")));
+            vm.ensNamehash(string(abi.encodePacked(LibString.toHexStringNoPrefix(addr), ".", "addr.reverse")));
         return INameResolver(ENS.resolver(node)).name(node);
     }
 

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -70,7 +70,7 @@ contract BaseTest is Test {
     COWShed userProxy;
     COWShed cowshedImpl = new COWShed();
     bytes32 baseName = "cowhooks.eth";
-    bytes32 baseNode = 0x8f8ff4ebd0ab36d517ed7387211b245b7d5508f4ed33be607a3ab54050f650d6;
+    bytes32 baseNode = vm.ensNamehash(LibString.fromSmallString(baseName));
 
     COWShedFactory factory;
     LibAuthenticatedHooksCalldataProxy cproxy = new LibAuthenticatedHooksCalldataProxy();

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -3,6 +3,12 @@ import { COWShed, Call } from "src/COWShed.sol";
 import { LibAuthenticatedHooks } from "src/LibAuthenticatedHooks.sol";
 import { COWShedFactory } from "src/COWShedFactory.sol";
 import { IMPLEMENTATION_STORAGE_SLOT } from "src/COWShedStorage.sol";
+import { ENS, INameResolver, IAddrResolver } from "src/ens.sol";
+import { LibString } from "solady/utils/LibString.sol";
+
+interface ICustomVM {
+    function ensNamehash(string calldata) external pure returns (bytes32);
+}
 
 contract LibAuthenticatedHooksCalldataProxy {
     function executeHooksMessageHash(Call[] calldata calls, bytes32 nonce, uint256 deadline)
@@ -67,7 +73,10 @@ contract BaseTest is Test {
     address userProxyAddr;
     COWShed userProxy;
     COWShed cowshedImpl = new COWShed();
-    COWShedFactory factory = new COWShedFactory(address(cowshedImpl));
+    bytes32 baseName = "cowhooks.eth";
+    bytes32 baseNode = 0x8f8ff4ebd0ab36d517ed7387211b245b7d5508f4ed33be607a3ab54050f650d6;
+
+    COWShedFactory factory;
     LibAuthenticatedHooksCalldataProxy cproxy = new LibAuthenticatedHooksCalldataProxy();
 
     address smartWalletAddr;
@@ -75,7 +84,15 @@ contract BaseTest is Test {
     address smartWalletProxyAddr;
     COWShed smartWalletProxy;
 
+    ICustomVM customVm = ICustomVM(address(vm));
+
     function setUp() external virtual {
+        uint256 nonce = vm.getNonce(address(this));
+        address factoryAddressExpected = vm.computeCreateAddress(address(this), nonce);
+        _setOwnerForEns(baseNode, address(factoryAddressExpected));
+        factory = new COWShedFactory(address(cowshedImpl), baseName, baseNode);
+        assertEq(address(factory), factoryAddressExpected, "factory address as not expected");
+
         user = vm.createWallet("user");
         userProxyAddr = factory.proxyOf(user.addr);
         userProxy = COWShed(payable(userProxyAddr));
@@ -86,6 +103,10 @@ contract BaseTest is Test {
         smartWalletProxyAddr = factory.proxyOf(smartWalletAddr);
         smartWalletProxy = COWShed(payable(smartWalletProxyAddr));
         _initializeSmartWalletProxy(smartWalletAddr);
+
+        assertEq(
+            _reverseResolve(0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045), "vitalik.eth", "reverse resolve impl failed"
+        );
     }
 
     function _initializeUserProxy(Vm.Wallet memory _wallet) internal returns (bytes memory signature) {
@@ -167,5 +188,26 @@ contract BaseTest is Test {
 
     function _deadline() internal view returns (uint256) {
         return block.timestamp + 1 hours;
+    }
+
+    function _resolveAddr(bytes32 node) internal view returns (address) {
+        return IAddrResolver(ENS.resolver(node)).addr(node);
+    }
+
+    function _reverseResolve(address addr) internal view returns (string memory) {
+        bytes32 node =
+            customVm.ensNamehash(string(abi.encodePacked(LibString.toHexStringNoPrefix(addr), ".", "addr.reverse")));
+        return INameResolver(ENS.resolver(node)).name(node);
+    }
+
+    function _recordOwnerSlotInEns(bytes32 node) internal pure returns (bytes32) {
+        // records mapping is in slot 0
+        // rest determined with https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html#mappings-and-dynamic-arrays
+        return keccak256(abi.encode(node, 0));
+    }
+
+    function _setOwnerForEns(bytes32 node, address owner) internal {
+        vm.store(address(ENS), _recordOwnerSlotInEns(node), bytes32(uint256(uint160(address(owner)))));
+        assertEq(ENS.owner(node), address(owner), "ens owner not set as expected");
     }
 }

--- a/test/COWShedFactory.t.sol
+++ b/test/COWShedFactory.t.sol
@@ -3,6 +3,11 @@ import { Vm, Test } from "forge-std/Test.sol";
 import { LibAuthenticatedHooks, Call } from "src/LibAuthenticatedHooks.sol";
 import { COWShed } from "src/COWShed.sol";
 import { BaseTest } from "./BaseTest.sol";
+import { LibString } from "solady/utils/LibString.sol";
+
+interface CustomVm {
+    function namehash(string calldata name) external pure returns (bytes32);
+}
 
 contract COWShedFactoryTest is BaseTest {
     function testExecuteHooks() external {
@@ -46,6 +51,38 @@ contract COWShedFactoryTest is BaseTest {
         assertTrue(
             proxy1.domainSeparator() != proxy2.domainSeparator(),
             "different proxies should have different domain separators"
+        );
+    }
+
+    function testForwardResolve() external view {
+        assertEq(
+            _resolveAddr(
+                customVm.ensNamehash(
+                    string(abi.encodePacked(LibString.toHexString(user.addr), ".", LibString.fromSmallString(baseName)))
+                )
+            ),
+            userProxyAddr
+        );
+        assertEq(
+            _resolveAddr(
+                customVm.ensNamehash(
+                    string(
+                        abi.encodePacked(
+                            LibString.toHexStringChecksummed(user.addr), ".", LibString.fromSmallString(baseName)
+                        )
+                    )
+                )
+            ),
+            userProxyAddr
+        );
+    }
+
+    function testReverseResolve() external view {
+        assertEq(
+            _reverseResolve(userProxyAddr),
+            string(
+                abi.encodePacked(LibString.toHexStringChecksummed(user.addr), ".", LibString.fromSmallString(baseName))
+            )
         );
     }
 }

--- a/test/COWShedFactory.t.sol
+++ b/test/COWShedFactory.t.sol
@@ -5,10 +5,6 @@ import { COWShed } from "src/COWShed.sol";
 import { BaseTest } from "./BaseTest.sol";
 import { LibString } from "solady/utils/LibString.sol";
 
-interface CustomVm {
-    function namehash(string calldata name) external pure returns (bytes32);
-}
-
 contract COWShedFactoryTest is BaseTest {
     function testExecuteHooks() external {
         Vm.Wallet memory wallet = vm.createWallet("testWallet");
@@ -57,7 +53,7 @@ contract COWShedFactoryTest is BaseTest {
     function testForwardResolve() external view {
         assertEq(
             _resolveAddr(
-                customVm.ensNamehash(
+                vm.ensNamehash(
                     string(abi.encodePacked(LibString.toHexString(user.addr), ".", LibString.fromSmallString(baseName)))
                 )
             ),
@@ -65,7 +61,7 @@ contract COWShedFactoryTest is BaseTest {
         );
         assertEq(
             _resolveAddr(
-                customVm.ensNamehash(
+                vm.ensNamehash(
                     string(
                         abi.encodePacked(
                             LibString.toHexStringChecksummed(user.addr), ".", LibString.fromSmallString(baseName)


### PR DESCRIPTION
Adds the ENS forward and reverse resolution logic.
- For reverse resolution, on proxy initialization, it transfers the reverse node's ownership to the factory contract and also sets it as the resolver.
- For forward resolution, it sets a new subnode record for the user's ens `<user-address>.<base-name>`