### PR TITLE
feat: init sdk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,5 +44,7 @@ jobs:
           node-version: latest
           cache: yarn
           cache-dependency-path: yarn.lock
+      - name: Install dependencies
+        run: yarn
       - name: Build
         run: yarn build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,17 @@ jobs:
         run: |
           forge test -vvv --fork-url ${{ secrets.RPC_URL }}
         id: test
+  sdk_check:
+    strategy:
+      fail-fast: true
+    name: SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: latest
+          cache: yarn
+          cache-dependency-path: yarn.lock
+      - name: Build
+        run: yarn build

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/
 # Dotenv file
 .env
 node_modules/
+dist/

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "build": "tsc"
+  },
   "dependencies": {
     "ethers": "^6.12.1",
     "typescript": "^5.4.5"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "ethers": "^6.12.1",
+    "ethers_v6": "npm:ethers@^6.12.1",
     "typescript": "^5.4.5"
   },
   "devDependencies": {

--- a/ts/constants.ts
+++ b/ts/constants.ts
@@ -1,0 +1,122 @@
+export const FACTORY_ABI = [
+  {
+    "type": "function",
+    "name": "executeHooks",
+    "inputs": [
+      {
+        "name": "calls",
+        "type": "tuple[]",
+        "internalType": "struct Call[]",
+        "components": [
+          {
+            "name": "target",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "callData",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allowFailure",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "isDelegateCall",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      },
+      {
+        "name": "nonce",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "signature",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+] as const;
+
+export const SHED_ABI = [
+  {
+    "type": "function",
+    "name": "executeHooks",
+    "inputs": [
+      {
+        "name": "calls",
+        "type": "tuple[]",
+        "internalType": "struct Call[]",
+        "components": [
+          {
+            "name": "target",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "callData",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allowFailure",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "isDelegateCall",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      },
+      {
+        "name": "nonce",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "signature",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+] as const;
+
+export const PROXY_CREATION_CODE = "0x"

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -5,21 +5,17 @@ import {
   solidityPackedKeccak256,
   TypedDataDomain,
   TypedDataEncoder,
-} from 'ethers';
+} from 'ethers_v6';
 import { FACTORY_ABI, PROXY_CREATION_CODE, SHED_ABI } from './constants';
 
-export const computeProxyAddress = (user: string) => {
-  getCreate2Address;
-};
-
-interface ISdkOptions {
+export interface ISdkOptions {
   factoryAddress: string;
   proxyCreationCode?: string;
   implementationAddress: string;
   chainId: number;
 }
 
-interface ICall {
+export interface ICall {
   target: string;
   value: bigint;
   callData: string;
@@ -27,7 +23,7 @@ interface ICall {
   isDelegateCall: boolean;
 }
 
-interface IExecuteHooks {
+export interface IExecuteHooks {
   calls: ICall[];
   nonce: string;
   deadline: bigint;
@@ -35,13 +31,16 @@ interface IExecuteHooks {
 
 const ABI_CODER = new ethers.AbiCoder();
 
-const COW_SHED_712_TYPES = {
+const DOMAIN_TYPE = {
   EIP712Domain: [
     { type: 'string', name: 'name' },
     { type: 'string', name: 'version' },
     { type: 'uint256', name: 'chainId' },
     { type: 'address', name: 'verifyingContract' },
   ],
+};
+
+const COW_SHED_712_TYPES = {
   ExecuteHooks: [
     { type: 'Call[]', name: 'calls' },
     { type: 'bytes32', name: 'nonce' },
@@ -79,8 +78,9 @@ export class CowShedSdk {
   }
 
   computeDomainSeparator(proxy: string) {
-    return TYPED_DATA_ENCODER.hashStruct(
+    return TypedDataEncoder.hashStruct(
       'EIP712Domain',
+      DOMAIN_TYPE,
       this._getDomain(proxy)
     );
   }
@@ -139,7 +139,7 @@ export class CowShedSdk {
   }
 
   static encodeEOASignature(r: bigint, s: bigint, v: number) {
-    return solidityPacked(['bytes32', 'bytes32', 'uint8'], [r, s, v]);
+    return solidityPacked(['uint', 'uint', 'uint8'], [r, s, v]);
   }
 
   private _hashToSign(

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -21,7 +21,7 @@ interface ISdkOptions {
 
 interface ICall {
   target: string;
-  value: bigint,
+  value: bigint;
   callData: string;
   allowFailure: boolean;
   isDelegateCall: boolean;
@@ -61,7 +61,7 @@ const FACTORY_INTERFACE: ethers.Interface = new ethers.Interface(FACTORY_ABI);
 const SHED_INTERFACE: ethers.Interface = new ethers.Interface(SHED_ABI);
 
 export class CowShedSdk {
-  constructor(private options: ISdkOptions) { }
+  constructor(private options: ISdkOptions) {}
 
   computeProxyAddress(user: string) {
     const salt = ABI_CODER.encode(['address'], [user]);
@@ -79,34 +79,85 @@ export class CowShedSdk {
   }
 
   computeDomainSeparator(proxy: string) {
-    return TYPED_DATA_ENCODER.hashStruct('EIP712Domain', this._getDomain(proxy));
+    return TYPED_DATA_ENCODER.hashStruct(
+      'EIP712Domain',
+      this._getDomain(proxy)
+    );
   }
 
-  hashToSignWithProxy(calls: ICall[], nonce: string, deadline: bigint, proxy: string) {
+  hashToSignWithProxy(
+    calls: ICall[],
+    nonce: string,
+    deadline: bigint,
+    proxy: string
+  ) {
     return this._hashToSign(calls, nonce, deadline, proxy);
   }
 
-  hashToSignWithUser(calls: ICall[], nonce: string, deadline: bigint, user: string) {
-    return this._hashToSign(calls, nonce, deadline, this.computeProxyAddress(user));
+  hashToSignWithUser(
+    calls: ICall[],
+    nonce: string,
+    deadline: bigint,
+    user: string
+  ) {
+    return this._hashToSign(
+      calls,
+      nonce,
+      deadline,
+      this.computeProxyAddress(user)
+    );
   }
 
-  static encodeExecuteHooksForFactory(calls: ICall[], nonce: string, deadline: bigint, user: string, signature: string) {
-    return FACTORY_INTERFACE.encodeFunctionData('executeHooks', [calls, nonce, deadline, user, signature]);
+  static encodeExecuteHooksForFactory(
+    calls: ICall[],
+    nonce: string,
+    deadline: bigint,
+    user: string,
+    signature: string
+  ) {
+    return FACTORY_INTERFACE.encodeFunctionData('executeHooks', [
+      calls,
+      nonce,
+      deadline,
+      user,
+      signature,
+    ]);
   }
 
-  static encodeExecuteHooksForProxy(calls: ICall[], nonce: string, deadline: bigint, signature: string) {
-    return SHED_INTERFACE.encodeFunctionData('executeHooks', [calls, nonce, deadline, signature]);
+  static encodeExecuteHooksForProxy(
+    calls: ICall[],
+    nonce: string,
+    deadline: bigint,
+    signature: string
+  ) {
+    return SHED_INTERFACE.encodeFunctionData('executeHooks', [
+      calls,
+      nonce,
+      deadline,
+      signature,
+    ]);
   }
 
   static encodeEOASignature(r: bigint, s: bigint, v: number) {
     return solidityPacked(['bytes32', 'bytes32', 'uint8'], [r, s, v]);
   }
 
-  private _hashToSign(calls: ICall[], nonce: string, deadline: bigint, proxy: string) {
+  private _hashToSign(
+    calls: ICall[],
+    nonce: string,
+    deadline: bigint,
+    proxy: string
+  ) {
     const message: IExecuteHooks = {
-      calls, nonce, deadline
+      calls,
+      nonce,
+      deadline,
     };
-    return TypedDataEncoder.hash(this._getDomain(proxy), COW_SHED_712_TYPES, message);
+    return TypedDataEncoder.hash(
+      this._getDomain(proxy),
+      COW_SHED_712_TYPES,
+      message
+    );
   }
 
   private _getDomain(proxy: string): TypedDataDomain {

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1,0 +1,125 @@
+import {
+  ethers,
+  getCreate2Address,
+  solidityPacked,
+  solidityPackedKeccak256,
+  TypedDataDomain,
+  TypedDataEncoder,
+} from 'ethers';
+import { FACTORY_ABI, PROXY_CREATION_CODE, SHED_ABI } from './constants';
+
+export const computeProxyAddress = (user: string) => {
+  getCreate2Address;
+};
+
+interface ISdkOptions {
+  factoryAddress: string;
+  proxyCreationCode?: string;
+  implementationAddress: string;
+  chainId: number;
+}
+
+interface ICall {
+  target: string;
+  value: bigint,
+  callData: string;
+  allowFailure: boolean;
+  isDelegateCall: boolean;
+}
+
+interface IExecuteHooks {
+  calls: ICall[];
+  nonce: string;
+  deadline: bigint;
+}
+
+const ABI_CODER = new ethers.AbiCoder();
+
+const COW_SHED_712_TYPES = {
+  EIP712Domain: [
+    { type: 'string', name: 'name' },
+    { type: 'string', name: 'version' },
+    { type: 'uint256', name: 'chainId' },
+    { type: 'address', name: 'verifyingContract' },
+  ],
+  ExecuteHooks: [
+    { type: 'Call[]', name: 'calls' },
+    { type: 'bytes32', name: 'nonce' },
+    { type: 'uint256', name: 'deadline' },
+  ],
+  Call: [
+    { type: 'address', name: 'target' },
+    { type: 'uint256', name: 'value' },
+    { type: 'bytes', name: 'callData' },
+    { type: 'bool', name: 'allowFailure' },
+    { type: 'bool', name: 'isDelegateCall' },
+  ],
+};
+const TYPED_DATA_ENCODER = new TypedDataEncoder(COW_SHED_712_TYPES);
+
+const FACTORY_INTERFACE: ethers.Interface = new ethers.Interface(FACTORY_ABI);
+const SHED_INTERFACE: ethers.Interface = new ethers.Interface(SHED_ABI);
+
+export class CowShedSdk {
+  constructor(private options: ISdkOptions) { }
+
+  computeProxyAddress(user: string) {
+    const salt = ABI_CODER.encode(['address'], [user]);
+    const initCodeHash = solidityPackedKeccak256(
+      ['bytes', 'bytes'],
+      [
+        this._proxyCreationCode(),
+        ABI_CODER.encode(
+          ['address', 'address'],
+          [this.options.implementationAddress, user]
+        ),
+      ]
+    );
+    return getCreate2Address(this.options.factoryAddress, salt, initCodeHash);
+  }
+
+  computeDomainSeparator(proxy: string) {
+    return TYPED_DATA_ENCODER.hashStruct('EIP712Domain', this._getDomain(proxy));
+  }
+
+  hashToSignWithProxy(calls: ICall[], nonce: string, deadline: bigint, proxy: string) {
+    return this._hashToSign(calls, nonce, deadline, proxy);
+  }
+
+  hashToSignWithUser(calls: ICall[], nonce: string, deadline: bigint, user: string) {
+    return this._hashToSign(calls, nonce, deadline, this.computeProxyAddress(user));
+  }
+
+  static encodeExecuteHooksForFactory(calls: ICall[], nonce: string, deadline: bigint, user: string, signature: string) {
+    return FACTORY_INTERFACE.encodeFunctionData('executeHooks', [calls, nonce, deadline, user, signature]);
+  }
+
+  static encodeExecuteHooksForProxy(calls: ICall[], nonce: string, deadline: bigint, signature: string) {
+    return SHED_INTERFACE.encodeFunctionData('executeHooks', [calls, nonce, deadline, signature]);
+  }
+
+  static encodeEOASignature(r: bigint, s: bigint, v: number) {
+    return solidityPacked(['bytes32', 'bytes32', 'uint8'], [r, s, v]);
+  }
+
+  private _hashToSign(calls: ICall[], nonce: string, deadline: bigint, proxy: string) {
+    const message: IExecuteHooks = {
+      calls, nonce, deadline
+    };
+    return TypedDataEncoder.hash(this._getDomain(proxy), COW_SHED_712_TYPES, message);
+  }
+
+  private _getDomain(proxy: string): TypedDataDomain {
+    const domain: TypedDataDomain = {
+      name: 'COWShed',
+      version: '1.0.0',
+      chainId: this.options.chainId,
+      verifyingContract: proxy,
+    };
+    return domain;
+  }
+
+  private _proxyCreationCode() {
+    return this.options.proxyCreationCode ?? PROXY_CREATION_CODE;
+  }
+}

--- a/ts/testUtil.ts
+++ b/ts/testUtil.ts
@@ -1,4 +1,4 @@
-import { TypedDataEncoder, ZeroAddress } from 'ethers';
+import { TypedDataEncoder, ZeroAddress } from 'ethers_v6';
 
 interface ICall {
   target: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,7 +55,7 @@
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,7 +99,7 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-ethers@^6.12.1:
+"ethers_v6@npm:ethers@^6.12.1":
   version "6.12.1"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.12.1.tgz#517ff6d66d4fd5433e38e903051da3e57c87ff37"
   integrity sha512-j6wcVoZf06nqEcBbDWkKg8Fp895SS96dSnTCjiXT+8vt2o02raTn4Lo9ERUuIVU5bAjoPYeA+7ytQFexFmLuVw==


### PR DESCRIPTION
Adds `CowShedSdk` with following utility functions:
- `computeProxyAddress` - getting proxy address for a given user
- `hashToSignXX` for getting message hash the user has to sign for given hooks call
- `computeDomainSeparator` - computing domain separator for a given proxy address 