### PR TITLE
perf: use Bitmap for gas efficiency in sequential nonces

### DIFF
--- a/src/COWShed.sol
+++ b/src/COWShed.sol
@@ -5,6 +5,7 @@ import { ICOWAuthHook, Call } from "./ICOWAuthHook.sol";
 import { LibAuthenticatedHooks } from "./LibAuthenticatedHooks.sol";
 import { COWShedStorage, IMPLEMENTATION_STORAGE_SLOT } from "./COWShedStorage.sol";
 import { REVERSE_REGISTRAR } from "./ens.sol";
+import { LibBitmap } from "solady/utils/LibBitmap.sol";
 
 contract COWShed is ICOWAuthHook, COWShedStorage {
     error InvalidSignature();
@@ -86,14 +87,14 @@ contract COWShed is ICOWAuthHook, COWShedStorage {
 
     /// @notice Revoke a given nonce. Only the proxy owner/admin can do this.
     function revokeNonce(bytes32 nonce) external onlyAdmin {
-        _consumeNonce(nonce);
+        _useNonce(nonce);
     }
 
     receive() external payable { }
 
     /// @notice returns if a nonce is already used.
     function nonces(bytes32 nonce) external view returns (bool) {
-        return _state().nonces[nonce];
+        return _isNonceUsed(nonce);
     }
 
     /// @notice EIP712 domain separator for the user proxy.
@@ -110,15 +111,8 @@ contract COWShed is ICOWAuthHook, COWShedStorage {
         return _state().trustedExecutor;
     }
 
-    function _consumeNonce(bytes32 _nonce) internal {
-        if (_state().nonces[_nonce]) {
-            revert NonceAlreadyUsed();
-        }
-        _state().nonces[_nonce] = true;
-    }
-
     function _executeCalls(Call[] calldata calls, bytes32 nonce) internal {
-        _consumeNonce(nonce);
+        _useNonce(nonce);
         LibAuthenticatedHooks.executeCalls(calls);
     }
 }

--- a/src/COWShed.sol
+++ b/src/COWShed.sol
@@ -5,7 +5,6 @@ import { ICOWAuthHook, Call } from "./ICOWAuthHook.sol";
 import { LibAuthenticatedHooks } from "./LibAuthenticatedHooks.sol";
 import { COWShedStorage, IMPLEMENTATION_STORAGE_SLOT } from "./COWShedStorage.sol";
 import { REVERSE_REGISTRAR } from "./ens.sol";
-import { LibBitmap } from "solady/utils/LibBitmap.sol";
 
 contract COWShed is ICOWAuthHook, COWShedStorage {
     error InvalidSignature();

--- a/src/COWShed.sol
+++ b/src/COWShed.sol
@@ -9,7 +9,6 @@ import { LibBitmap } from "solady/utils/LibBitmap.sol";
 
 contract COWShed is ICOWAuthHook, COWShedStorage {
     error InvalidSignature();
-    error NonceAlreadyUsed();
     error OnlyTrustedExecutor();
     error OnlySelf();
     error AlreadyInitialized();

--- a/src/COWShedStorage.sol
+++ b/src/COWShedStorage.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
+import { LibBitmap } from "solady/utils/LibBitmap.sol";
+
 /// @dev bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
 bytes32 constant IMPLEMENTATION_STORAGE_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
 
@@ -9,10 +11,12 @@ interface IAdminView {
 }
 
 contract COWShedStorage {
+    using LibBitmap for LibBitmap.Bitmap;
+
     struct State {
         bool initialized;
         address trustedExecutor;
-        mapping(bytes32 => bool) nonces;
+        LibBitmap.Bitmap nonces;
     }
 
     bytes32 internal constant STATE_STORAGE_SLOT = keccak256("COWShed.State");
@@ -26,5 +30,13 @@ contract COWShedStorage {
 
     function _admin() internal view returns (address) {
         return IAdminView(address(this)).admin();
+    }
+
+    function _useNonce(bytes32 _nonce) internal {
+        _state().nonces.set(uint256(_nonce));
+    }
+
+    function _isNonceUsed(bytes32 _nonce) internal view returns (bool) {
+        return _state().nonces.get(uint256(_nonce));
     }
 }

--- a/src/COWShedStorage.sol
+++ b/src/COWShedStorage.sol
@@ -13,6 +13,8 @@ interface IAdminView {
 contract COWShedStorage {
     using LibBitmap for LibBitmap.Bitmap;
 
+    error NonceAlreadyUsed();
+
     struct State {
         bool initialized;
         address trustedExecutor;
@@ -33,6 +35,7 @@ contract COWShedStorage {
     }
 
     function _useNonce(bytes32 _nonce) internal {
+        if (_isNonceUsed(_nonce)) revert NonceAlreadyUsed();
         _state().nonces.set(uint256(_nonce));
     }
 

--- a/test/COWShed.t.sol
+++ b/test/COWShed.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
-import { COWShed, Call } from "src/COWShed.sol";
+import { COWShedStorage, COWShed, Call } from "src/COWShed.sol";
 import { Test, Vm } from "forge-std/Test.sol";
 import { COWShedFactory, COWShedProxy } from "src/COWShedFactory.sol";
 import { BaseTest } from "./BaseTest.sol";
@@ -121,7 +121,7 @@ contract COWShedTest is BaseTest {
         userProxy.revokeNonce(nonce);
         assertTrue(userProxy.nonces(nonce), "nonce is not used yet");
 
-        vm.expectRevert(COWShed.NonceAlreadyUsed.selector);
+        vm.expectRevert(COWShedStorage.NonceAlreadyUsed.selector);
         userProxy.executeHooks(calls, nonce, _deadline(), signature);
     }
 


### PR DESCRIPTION
Improve gas efficiency for sequential nonce by using a bitmap that wont initialize a new slot for every new nonce. This is done by packing multiple boolean values in a single slot.